### PR TITLE
Add custom source sha

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,3 +130,13 @@ jobs:
           echo "${{ toJSON(steps.changed-files-specific-comma.outputs) }}"
         shell:
           bash
+      - name: Run changed-files with custom sha
+        id: changed-files-custom-sha
+        uses: ./
+        with:
+          sha: ${{ github.event.pull_request.head.sha && github.event.pull_request.head.sha || github.sha }}
+      - name: Show output
+        run: |
+          echo "${{ toJSON(steps.changed-files-custom-sha.outputs) }}"
+        shell:
+          bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,7 +134,7 @@ jobs:
         id: changed-files-custom-sha
         uses: ./
         with:
-          sha: ${{ github.event.pull_request.head.sha && github.event.pull_request.head.sha || github.sha }}
+          sha: ${{ github.event.pull_request.head.sha }}
       - name: Show output
         run: |
           echo "${{ toJSON(steps.changed-files-custom-sha.outputs) }}"

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ jobs:
          if: steps.changed-files-specific.outputs.any_changed == 'true'
          run: |
            echo "One or more files listed above has changed."
-      - name: Add custom source sha
+      - name: Use a different commit SHA as the base
         id: changed-files-comma
         uses: tj-actions/changed-files@v8.4
         with:

--- a/README.md
+++ b/README.md
@@ -149,6 +149,11 @@ jobs:
          if: steps.changed-files-specific.outputs.any_changed == 'true'
          run: |
            echo "One or more files listed above has changed."
+      - name: Add custom source sha
+        id: changed-files-comma
+        uses: tj-actions/changed-files@v8.4
+        with:
+          sha: ${{ github.event.pull_request.head.sha }}
         
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -15,9 +15,9 @@ inputs:
     required: false
     default: ""
   sha:
-    description: 'Commit sha'
-    required: false
-    default: ""
+    description: 'Specify a different commit SHA to be used for comparing changes'
+    required: true
+    default: ${{ github.sha }}
 
 outputs:
   added_files:
@@ -58,8 +58,6 @@ runs:
   using: 'composite'
   steps:
     - run: |
-        # Override GITHUB_SHA if we have inputs.sha
-        export GITHUB_SHA=${{ inputs.sha != '' && inputs.sha || github.sha }}
         bash $GITHUB_ACTION_PATH/entrypoint.sh
       id: changed-files
       shell: bash
@@ -68,6 +66,7 @@ runs:
         GITHUB_REPOSITORY: ${{ github.repository }}
         # INPUT_<VARIABLE_NAME> is not available in Composite run steps
         # https://github.community/t/input-variable-name-is-not-available-in-composite-run-steps/127611
+        INPUT_SHA: ${{ inputs.sha }}
         INPUT_TOKEN: ${{ inputs.token }}
         INPUT_FILES: ${{ inputs.files }}
         INPUT_SEPARATOR: ${{ inputs.separator }}

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Check for changes using only this list of files (Defaults to the entire repo)'
     required: false
     default: ""
+  sha:
+    description: 'Commit sha'
+    required: false
+    default: ""
 
 outputs:
   added_files:
@@ -54,11 +58,12 @@ runs:
   using: 'composite'
   steps:
     - run: |
+        # Override GITHUB_SHA if we have inputs.sha
+        export GITHUB_SHA=${{ inputs.sha != '' && inputs.sha || github.sha }}
         bash $GITHUB_ACTION_PATH/entrypoint.sh
       id: changed-files
       shell: bash
       env:
-        GITHUB_SHA: ${{ github.sha }}
         GITHUB_BASE_REF: ${{ github.base_ref }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         # INPUT_<VARIABLE_NAME> is not available in Composite run steps

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,10 +8,10 @@ git remote set-url origin "https://${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY
 
 echo "Getting HEAD info..."
 
-if [[ -z $GITHUB_SHA ]]; then
+if [[ -z $INPUT_SHA ]]; then
   CURR_SHA=$(git rev-parse HEAD 2>&1) && exit_status=$? || exit_status=$?
 else
-  CURR_SHA=$GITHUB_SHA
+  CURR_SHA=$INPUT_SHA
 fi
 
 if [[ $exit_status -ne 0 ]]; then


### PR DESCRIPTION
### Why I did this PR
I hit the issue when I created PR and when I use:
```
      - name: Github checkout
        uses: actions/checkout@v2
        with:
          ref: ${{ github.head_ref }}
          fetch-depth: 0
```
When we use `github.head_ref` we checkout the current branch. But after that the script gets `github.sha` but the value of sha is not equal to the PR value, so we have difference between the branch sha and the `github.sha`. I receive similar error: 
```
  fatal: bad object 75e655dddc4f3eb8c0748b95bdd1a44f3a758b0f
  fatal: bad object 75e655dddc4f3eb8c0748b95bdd1a44f3a758b0f
  fatal: bad object 75e655dddc4f3eb8c0748b95bdd1a44f3a758b0f
  fatal: bad object 75e655dddc4f3eb8c0748b95bdd1a44f3a758b0f
  fatal: bad object 75e655dddc4f3eb8c0748b95bdd1a44f3a758b0f
  fatal: bad object 75e655dddc4f3eb8c0748b95bdd1a44f3a758b0f
  fatal: bad object 75e655dddc4f3eb8c0748b95bdd1a44f3a758b0f
  fatal: bad object 75e655dddc4f3eb8c0748b95bdd1a44f3a758b0f
  fatal: bad object 75e655dddc4f3eb8c0748b95bdd1a44f3a758b0f
```
With this PR we can pass the source sha and now I can pass the correct sha for the source branch and all works well.

Why I use: `export GITHUB_SHA=${{ inputs.sha != '' && inputs.sha || github.sha }}` vs `GITHUB_SHA=${{ inputs.sha != '' && inputs.sha || github.sha }}` in env section: When we use env section we pass variable but after that the Github action override `GITHUB_SHA` and in order to avoid this I just add `export` right before entrypoint execution.
