### PR TITLE
Implement path parameter

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -32,6 +32,16 @@
         "code",
         "doc"
       ]
+    },
+    {
+      "login": "IvanPizhenko",
+      "name": "Ivan Pizhenko",
+      "avatar_url": "https://avatars.githubusercontent.com/u/11859904?v=4",
+      "profile": "https://github.com/IvanPizhenko",
+      "contributions": [
+        "code",
+        "doc"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,10 @@ jobs:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Checkout into dir1
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,12 +31,12 @@ jobs:
     steps:
       - name: Checkout to branch
         uses: actions/checkout@v2
-      
+
       - name: Run changed-files with defaults
         id: changed-files
         continue-on-error: true
         uses: ./
-      
+
       - name: Show output
         run: |
           echo "${{ toJSON(steps.changed-files.outputs) }}"
@@ -235,5 +235,31 @@ jobs:
       - name: Show output
         run: |
           echo "${{ toJSON(steps.changed-files-specific-only-changed.outputs) }}"
+        shell:
+          bash
+      - name: Remove current checkout
+        run: rm -rf ./*
+        shell:
+          bash
+      - name: Checkout into another_dir
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: another_dir
+      - name: Run changed-files with defaults on another_dir
+        id: changed-files-another-dir
+        uses: ./
+        with:
+          path: another_dir
+      - name: Show output
+        run: |
+          echo "${{ toJSON(steps.changed-files-another-dir.outputs) }}"
+        shell:
+          bash
+      - name: List all modified files
+        run: |
+          for file in "${{ steps.changed-files-another-dir.outputs.modified_files }}"; do
+            echo $file
+          done
         shell:
           bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,59 @@ jobs:
       - name: shellcheck
         uses: reviewdog/action-shellcheck@v1.7
 
+  test-multiple-repositories:
+    name: Test with multiple repositories
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - name: Checkout into dir1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: dir1
+      - name: Run changed-files with defaults on the dir1
+        id: changed-files-dir1
+        uses: ./
+        with:
+          path: dir1
+      - name: Show output
+        run: |
+          echo "${{ toJSON(steps.changed-files-dir1.outputs) }}"
+        shell:
+          bash
+      - name: List all modified files
+        run: |
+          for file in "${{ steps.changed-files-dir1.outputs.modified_files }}"; do
+            echo $file
+          done
+        shell:
+          bash
+      - name: Checkout into dir2
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: dir2
+      - name: Run changed-files with defaults on the dir2
+        id: changed-files-dir2
+        uses: ./
+        with:
+          path: dir2
+      - name: Show output
+        run: |
+          echo "${{ toJSON(steps.changed-files-dir2.outputs) }}"
+        shell:
+          bash
+      - name: List all modified files
+        run: |
+          for file in "${{ steps.changed-files-dir2.outputs.modified_files }}"; do
+            echo $file
+          done
+        shell:
+          bash
+
   test-no-head-sha:
     name: Test changed-files missing head sha
     runs-on: ${{ matrix.platform }}
@@ -235,31 +288,5 @@ jobs:
       - name: Show output
         run: |
           echo "${{ toJSON(steps.changed-files-specific-only-changed.outputs) }}"
-        shell:
-          bash
-      - name: Remove current checkout
-        run: rm -rf ./*
-        shell:
-          bash
-      - name: Checkout into another_dir
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          path: another_dir
-      - name: Run changed-files with defaults on another_dir
-        id: changed-files-another-dir
-        uses: ./
-        with:
-          path: another_dir
-      - name: Show output
-        run: |
-          echo "${{ toJSON(steps.changed-files-another-dir.outputs) }}"
-        shell:
-          bash
-      - name: List all modified files
-        run: |
-          for file in "${{ steps.changed-files-another-dir.outputs.modified_files }}"; do
-            echo $file
-          done
         shell:
           bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,6 @@ jobs:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Checkout into dir1
         uses: actions/checkout@v2
         with:
@@ -39,7 +35,7 @@ jobs:
           path: dir1
       - name: Run changed-files with defaults on the dir1
         id: changed-files-dir1
-        uses: ./
+        uses: ./dir1
         with:
           path: dir1
       - name: Show output
@@ -61,7 +57,7 @@ jobs:
           path: dir2
       - name: Run changed-files with defaults on the dir2
         id: changed-files-dir2
-        uses: ./
+        uses: ./dir2
         with:
           path: dir2
       - name: Show output

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 .envrc
+tag.sh
+untag.sh

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ jobs:
 | base_sha           |  `string`      |    `false`     |                     | Specify a different <br> base commit SHA <br> used for <br> comparing changes  |
 | sha           |  `string`      |    `true`     | `${{ github.sha }}`           | Specify a different <br> commit SHA <br> used for <br> comparing changes  |
 | files_from_source_file |  `string`      |    `false`     |                    | Source file <br> used to populate <br> the files input |
-| path | `string` | `false` | no default value | Relative path under `GITHUB_WORKSPACE` to the repository |
+| path | `string` | `false` |  | Relative path under <br> `GITHUB_WORKSPACE` <br> to the repository |
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ jobs:
 | base_sha           |  `string`      |    `false`     |                     | Specify a different <br> base commit SHA <br> used for <br> comparing changes  |
 | sha           |  `string`      |    `true`     | `${{ github.sha }}`           | Specify a different <br> commit SHA <br> used for <br> comparing changes  |
 | files_from_source_file |  `string`      |    `false`     |                    | Source file <br> used to populate <br> the files input |
-| path | `string` | `false` | no default value | Checkout path (same as used in the GitHub checkout action) |
+| path | `string` | `false` | no default value | Relative path under `GITHUB_WORKSPACE` to the repository |
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # OR "2" -> To retrieve the preceding commit.
-      
+
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v1.0.0
-      
+
       - name: List all modified files
         run: |
           for file in "${{ steps.changed-files.outputs.all_modified_files }}"; do
@@ -104,6 +104,7 @@ jobs:
 | base_sha           |  `string`      |    `false`     |                     | Specify a different <br> base commit SHA <br> used for <br> comparing changes  |
 | sha           |  `string`      |    `true`     | `${{ github.sha }}`           | Specify a different <br> commit SHA <br> used for <br> comparing changes  |
 | files_from_source_file |  `string`      |    `false`     |                    | Source file <br> used to populate <br> the files input |
+| path | `string` | `false` | no default value | Checkout path (same as used in the GitHub checkout action) |
 
 ## Example
 
@@ -115,7 +116,7 @@ jobs:
       - name: Get changed files using defaults
         id: changed-files
         uses: tj-actions/changed-files@v1.0.0
-      
+
       - name: Get changed files using a comma separator
         id: changed-files-comma
         uses: tj-actions/changed-files@v1.0.0
@@ -148,7 +149,7 @@ jobs:
             new.txt
             test_directory
             *.sh
-            .(png|jpeg)$   
+            .(png|jpeg)$
             .(sql)$
             ^(mynewfile|custom)
 
@@ -156,12 +157,12 @@ jobs:
         if: steps.changed-files-specific.outputs.any_changed == 'true'
         run: |
           echo "One or more files listed above has changed."
-          
+
       - name: Run step if only the files listed above change
         if: steps.changed-files-specific.outputs.only_changed == 'true'
         run: |
           echo "Only files listed above have changed."
-      
+
       - name: Use a source file or list of file(s) to populate to files input.
         id: changed-files-specific-source-file
         uses: tj-actions/changed-files@v1.0.0
@@ -183,13 +184,13 @@ jobs:
         uses: tj-actions/changed-files@v1.0.0
         with:
           sha: ${{ github.event.pull_request.head.sha }}
-          
+
       - name: Use a different base SHA
         id: changed-files-custom-base-sha
         uses: tj-actions/changed-files@v1.0.0
         with:
           base_sha: "2096ed0"
-        
+
 ```
 
 ### Running [pre-commit](https://pre-commit.com/) on all modified files
@@ -200,7 +201,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      
+
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v1.0.0

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
   base_sha:
     description: 'Specify a base commit SHA on used for comparing changes'
     required: false
+  path:
+    description: 'Specify checkout path (same as in the GitHub checkout action)'
+    required: false
 
 outputs:
   added_files:
@@ -100,6 +103,7 @@ runs:
         INPUT_TOKEN: ${{ inputs.token }}
         INPUT_FILES: ${{ join(format('{0} {1}', inputs.files, steps.source-input-files.outputs.files), ' ') }}
         INPUT_SEPARATOR: ${{ inputs.separator }}
+        INPUT_PATH: ${{ inputs.path }}
 
 branding:
   icon: file-text

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     description: 'Specify a base commit SHA on used for comparing changes'
     required: false
   path:
-    description: 'Specify a relative path under $GITHUB_WORKSPACE to location of the repository'
+    description: 'Specify a relative path under $GITHUB_WORKSPACE to locate the repository'
     required: false
 
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     description: 'Specify a base commit SHA on used for comparing changes'
     required: false
   path:
-    description: 'Specify checkout path (same as in the GitHub checkout action)'
+    description: 'Specify a relative path under $GITHUB_WORKSPACE to location of the repository'
     required: false
 
 outputs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,17 @@ set -e
 
 echo "::group::changed-files"
 
+echo "Resolving repository path..."
+if [[ ! -z $INPUT_PATH ]]; then
+  CONSTRUCTED_REPO_DIR="$GITHUB_WORKSPACE/$INPUT_PATH"
+  REAL_REPO_DIR=$(realpath "$CONSTRUCTED_REPO_DIR")
+  if [[ ! -d "$REAL_REPO_DIR" ]]; then
+    echo "::warning::Invalid repository directory"
+    exit 1
+  fi
+  cd "$REAL_REPO_DIR"
+fi
+
 git remote add temp_changed_files "https://${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}"
 
 echo "Getting HEAD info..."
@@ -27,7 +38,7 @@ if [[ -z $GITHUB_BASE_REF ]]; then
   fi
   TARGET_BRANCH=${GITHUB_REF/refs\/heads\//}
   CURRENT_BRANCH=$TARGET_BRANCH
-  
+
   if [[ $exit_status -ne 0 ]]; then
     echo "::warning::Unable to determine the previous commit sha"
     echo "::warning::You seem to be missing 'fetch-depth: 0' or 'fetch-depth: 2'. See https://github.com/tj-actions/changed-files#usage"
@@ -42,7 +53,7 @@ else
   else
     PREVIOUS_SHA=$INPUT_BASE_SHA
   fi
-  
+
   if [[ $exit_status -ne 0 ]]; then
     echo "::warning::Unable to determine the base ref sha for ${TARGET_BRANCH}"
     exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,7 @@ set -e
 echo "::group::changed-files"
 
 echo "Resolving repository path..."
+
 if [[ ! -z $INPUT_PATH ]]; then
   CONSTRUCTED_REPO_DIR="$GITHUB_WORKSPACE/$INPUT_PATH"
   REAL_REPO_DIR=$(realpath "$CONSTRUCTED_REPO_DIR")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ echo "::group::changed-files"
 
 echo "Resolving repository path..."
 
-if [[ ! -z $INPUT_PATH ]]; then
+if [[ -n $INPUT_PATH ]]; then
   REPO_DIR="$GITHUB_WORKSPACE/$INPUT_PATH"
   if [[ ! -d "$REPO_DIR" ]]; then
     echo "::warning::Invalid repository path"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,13 +7,12 @@ echo "::group::changed-files"
 echo "Resolving repository path..."
 
 if [[ ! -z $INPUT_PATH ]]; then
-  CONSTRUCTED_REPO_DIR="$GITHUB_WORKSPACE/$INPUT_PATH"
-  REAL_REPO_DIR=$(realpath "$CONSTRUCTED_REPO_DIR")
-  if [[ ! -d "$REAL_REPO_DIR" ]]; then
-    echo "::warning::Invalid repository directory"
+  REPO_DIR="$GITHUB_WORKSPACE/$INPUT_PATH"
+  if [[ ! -d "$REPO_DIR" ]]; then
+    echo "::warning::Invalid repository path"
     exit 1
   fi
-  cd "$REAL_REPO_DIR"
+  cd "$REPO_DIR"
 fi
 
 git remote add temp_changed_files "https://${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}"


### PR DESCRIPTION
This PR implements `path` parameter (similar to GitHub checkout action) to be able to work with multiple repositories.

close #167 