### PR TITLE
Deduplicate from files parameter without sorting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,9 +222,18 @@ jobs:
           files: |
             .github/workflows/test.yml
             action.yml
+            test/changed-files-list.txt
+            !*.txt
       - name: Show output
         run: |
           echo '${{ toJSON(steps.changed-files-specific.outputs) }}'
+        shell:
+          bash
+      - name: Check if a excluded file is not included in any_changed
+        if: "contains(steps.changed-files-specific.outputs.all_changed_files, 'test/changed-files-list.txt')"
+        run: |
+          echo "Invalid output: Expected (true) got (${{ steps.changed-files-specific.outputs.any_changed }})"
+          exit 1
         shell:
           bash
       - name: Verify any_changed for specific files
@@ -236,6 +245,13 @@ jobs:
           fi
         shell:
           bash
+      - name: Check if a excluded file is not included in any_modified
+        if: "contains(steps.changed-files-specific.outputs.all_modified_files, 'test/changed-files-list.txt')"
+        run: |
+          echo "Invalid output: Expected (true) got (${{ steps.changed-files-specific.outputs.any_modified }})"
+          exit 1
+        shell:
+          bash
       - name: Verify any_modified for specific files
         if: "!contains(steps.changed-files-specific.outputs.all_modified_files, 'action.yml') && !contains(steps.changed-files-specific.outputs.all_modified_files, '.github/workflows/test.yml')"
         run: |
@@ -243,6 +259,13 @@ jobs:
             echo "Invalid output: Expected (false) got (${{ steps.changed-files-specific.outputs.any_modified }})"
             exit 1
           fi
+        shell:
+          bash
+      - name: Check if a excluded file is not included in any_deleted
+        if: "contains(steps.changed-files-specific.outputs.deleted_files, 'test/changed-files-list.txt')"
+        run: |
+          echo "Invalid output: Expected (true) got (${{ steps.changed-files-specific.outputs.any_deleted }})"
+          exit 1
         shell:
           bash
       - name: Verify any_deleted for specific files
@@ -426,6 +449,13 @@ jobs:
             test/changed-files-list.txt
           files: |
             **/workflows/rebase.yml
+      - name: Check if a excluded file is not included in any_changed
+        if: contains(steps.changed-files-specific-source-file.outputs.all_changed_files, 'test/changed-files-list.txt')
+        run: |
+          echo "Invalid output: Expected (true) got (${{ steps.changed-files-specific-source-file.outputs.any_changed }})"
+          exit 1
+        shell:
+          bash
       - name: Verify any_changed from source files
         if: |
           (
@@ -440,6 +470,13 @@ jobs:
           fi
         shell:
           bash
+      - name: Check if a excluded file is not included in any_modified
+        if: contains(steps.changed-files-specific-source-file.outputs.all_modified_files, 'test/changed-files-list.txt')
+        run: |
+          echo "Invalid output: Expected (true) got (${{ steps.changed-files-specific-source-file.outputs.any_modified }})"
+          exit 1
+        shell:
+          bash
       - name: Verify any_modified from source files
         if: |
           (
@@ -452,6 +489,13 @@ jobs:
             echo "Invalid output: Expected (false) got (${{ steps.changed-files-specific-source-file.outputs.any_modified }})"
             exit 1
           fi
+        shell:
+          bash
+      - name: Check if a excluded file is not included in any_deleted
+        if: contains(steps.changed-files-specific-source-file.outputs.deleted_files, 'test/changed-files-list.txt')
+        run: |
+          echo "Invalid output: Expected (true) got (${{ steps.changed-files-specific-source-file.outputs.any_deleted }})"
+          exit 1
         shell:
           bash
       - name: Verify any_deleted from source files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,7 +223,7 @@ jobs:
             .github/workflows/test.yml
             action.yml
             test/changed-files-list.txt
-            !*.txt
+            !**/*.txt
       - name: Show output
         run: |
           echo '${{ toJSON(steps.changed-files-specific.outputs) }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -452,7 +452,7 @@ jobs:
       - name: Check if a excluded file is not included in any_changed
         if: contains(steps.changed-files-specific-source-file.outputs.all_changed_files, 'test/changed-files-list.txt')
         run: |
-          echo "Invalid output: Expected (true) got (${{ steps.changed-files-specific-source-file.outputs.any_changed }})"
+          echo "Invalid output: Expected not to include (test/changed-files-list.txt) got (${{ steps.changed-files-specific-source-file.outputs.all_changed_files }})"
           exit 1
         shell:
           bash
@@ -473,7 +473,7 @@ jobs:
       - name: Check if a excluded file is not included in any_modified
         if: contains(steps.changed-files-specific-source-file.outputs.all_modified_files, 'test/changed-files-list.txt')
         run: |
-          echo "Invalid output: Expected (true) got (${{ steps.changed-files-specific-source-file.outputs.any_modified }})"
+          echo "Invalid output: Expected not to include (test/changed-files-list.txt) got (${{ steps.changed-files-specific-source-file.outputs.all_modified_files }})"
           exit 1
         shell:
           bash
@@ -494,7 +494,7 @@ jobs:
       - name: Check if a excluded file is not included in any_deleted
         if: contains(steps.changed-files-specific-source-file.outputs.deleted_files, 'test/changed-files-list.txt')
         run: |
-          echo "Invalid output: Expected (true) got (${{ steps.changed-files-specific-source-file.outputs.any_deleted }})"
+          echo "Invalid output: Expected not to include (test/changed-files-list.txt) got (${{ steps.changed-files-specific-source-file.outputs.deleted_files }})"
           exit 1
         shell:
           bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Check if a excluded file is not included in any_changed
         if: "contains(steps.changed-files-specific.outputs.all_changed_files, 'test/changed-files-list.txt')"
         run: |
-          echo "Invalid output: Expected (true) got (${{ steps.changed-files-specific.outputs.any_changed }})"
+          echo "Invalid output: Expected not to include (test/changed-files-list.txt) got (${{ steps.changed-files-specific.outputs.all_changed_files }})"
           exit 1
         shell:
           bash
@@ -248,7 +248,7 @@ jobs:
       - name: Check if a excluded file is not included in any_modified
         if: "contains(steps.changed-files-specific.outputs.all_modified_files, 'test/changed-files-list.txt')"
         run: |
-          echo "Invalid output: Expected (true) got (${{ steps.changed-files-specific.outputs.any_modified }})"
+          echo "Invalid output: Expected not to include (test/changed-files-list.txt) got (${{ steps.changed-files-specific.outputs.all_modified_files }})"
           exit 1
         shell:
           bash
@@ -264,7 +264,7 @@ jobs:
       - name: Check if a excluded file is not included in any_deleted
         if: "contains(steps.changed-files-specific.outputs.deleted_files, 'test/changed-files-list.txt')"
         run: |
-          echo "Invalid output: Expected (true) got (${{ steps.changed-files-specific.outputs.any_deleted }})"
+          echo "Invalid output: Expected not to include (test/changed-files-list.txt) got (${{ steps.changed-files-specific.outputs.deleted_files }})"
           exit 1
         shell:
           bash

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -134,7 +134,7 @@ else
 
   if [[ -n $ALL_OTHER_CHANGED ]]; then
     if [[ -n "$UNIQUE_ALL_CHANGED" ]]; then
-      OTHER_CHANGED=$(echo "${ALL_OTHER_CHANGED}|${UNIQUE_ALL_CHANGED}"  | awk '{gsub(/\|/,"\n"); print $0;}' | uniq -u | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
+      OTHER_CHANGED=$(echo "${ALL_OTHER_CHANGED}|${UNIQUE_ALL_CHANGED}"  | awk '{gsub(/\|/,"\n"); print $0;}' | sort | uniq -u | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
     else
       OTHER_CHANGED=$ALL_OTHER_CHANGED
     fi
@@ -164,7 +164,7 @@ else
 
   if [[ -n $ALL_OTHER_MODIFIED ]]; then
     if [[ -n "$UNIQUE_ALL_MODIFIED" ]]; then
-      OTHER_MODIFIED=$(echo "${ALL_OTHER_MODIFIED}|${UNIQUE_ALL_MODIFIED}"  | awk '{gsub(/\|/,"\n"); print $0;}' | uniq -u | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
+      OTHER_MODIFIED=$(echo "${ALL_OTHER_MODIFIED}|${UNIQUE_ALL_MODIFIED}"  | awk '{gsub(/\|/,"\n"); print $0;}' | sort | uniq -u | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
     else
       OTHER_MODIFIED=$ALL_OTHER_MODIFIED
     fi
@@ -194,7 +194,7 @@ else
 
   if [[ -n $ALL_OTHER_DELETED ]]; then
     if [[ -n "$UNIQUE_ALL_DELETED" ]]; then
-      OTHER_DELETED=$(echo "${ALL_OTHER_DELETED}|${UNIQUE_ALL_DELETED}" | awk '{gsub(/\|/,"\n"); print $0;}' | uniq -u | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
+      OTHER_DELETED=$(echo "${ALL_OTHER_DELETED}|${UNIQUE_ALL_DELETED}" | awk '{gsub(/\|/,"\n"); print $0;}' | sort | uniq -u | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
     else
       OTHER_DELETED=$ALL_OTHER_DELETED
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -121,7 +121,7 @@ else
   ALL_MODIFIED=$(git diff --diff-filter="ACMRD" --name-only "$PREVIOUS_SHA" "$CURRENT_SHA" | grep -E "(${INPUT_FILES})" | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
 
   ALL_OTHER_CHANGED=$(git diff --diff-filter="ACMR" --name-only "$PREVIOUS_SHA" "$CURRENT_SHA" | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
-  UNIQUE_ALL_CHANGED=$(echo "${ALL_CHANGED}" | awk '{gsub(/\|/,"\n"); print $0;}' | sort -u | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
+  UNIQUE_ALL_CHANGED=$(echo "${ALL_CHANGED}" | awk '{gsub(/\|/,"\n"); print $0;}' | awk '!a[$0]++' | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
 
   if [[ -n "${UNIQUE_ALL_CHANGED}" ]]; then
     echo "Matching changed files: ${UNIQUE_ALL_CHANGED}"
@@ -134,7 +134,7 @@ else
 
   if [[ -n $ALL_OTHER_CHANGED ]]; then
     if [[ -n "$UNIQUE_ALL_CHANGED" ]]; then
-      OTHER_CHANGED=$(echo "${ALL_OTHER_CHANGED}|${UNIQUE_ALL_CHANGED}"  | awk '{gsub(/\|/,"\n"); print $0;}' | sort | uniq -u | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
+      OTHER_CHANGED=$(echo "${ALL_OTHER_CHANGED}|${UNIQUE_ALL_CHANGED}"  | awk '{gsub(/\|/,"\n"); print $0;}' | uniq -u | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
     else
       OTHER_CHANGED=$ALL_OTHER_CHANGED
     fi
@@ -151,7 +151,7 @@ else
   fi
 
   ALL_OTHER_MODIFIED=$(git diff --diff-filter="ACMRD" --name-only "$PREVIOUS_SHA" "$CURRENT_SHA" | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
-  UNIQUE_ALL_MODIFIED=$(echo "${ALL_MODIFIED}" | awk '{gsub(/\|/,"\n"); print $0;}' | sort -u | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
+  UNIQUE_ALL_MODIFIED=$(echo "${ALL_MODIFIED}" | awk '{gsub(/\|/,"\n"); print $0;}' | awk '!a[$0]++' | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
 
   if [[ -n "${UNIQUE_ALL_MODIFIED}" ]]; then
     echo "Matching modified files: ${UNIQUE_ALL_MODIFIED}"
@@ -164,7 +164,7 @@ else
 
   if [[ -n $ALL_OTHER_MODIFIED ]]; then
     if [[ -n "$UNIQUE_ALL_MODIFIED" ]]; then
-      OTHER_MODIFIED=$(echo "${ALL_OTHER_MODIFIED}|${UNIQUE_ALL_MODIFIED}"  | awk '{gsub(/\|/,"\n"); print $0;}' | sort | uniq -u | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
+      OTHER_MODIFIED=$(echo "${ALL_OTHER_MODIFIED}|${UNIQUE_ALL_MODIFIED}"  | awk '{gsub(/\|/,"\n"); print $0;}' | uniq -u | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
     else
       OTHER_MODIFIED=$ALL_OTHER_MODIFIED
     fi
@@ -181,7 +181,7 @@ else
   fi
 
   ALL_OTHER_DELETED=$(git diff --diff-filter=D --name-only "$PREVIOUS_SHA" "$CURRENT_SHA" | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
-  UNIQUE_ALL_DELETED=$(echo "${DELETED}" | awk '{gsub(/\|/,"\n"); print $0;}' | sort -u | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
+  UNIQUE_ALL_DELETED=$(echo "${DELETED}" | awk '{gsub(/\|/,"\n"); print $0;}' | awk '!a[$0]++' | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
 
   if [[ -n "${UNIQUE_ALL_DELETED}" ]]; then
     echo "Matching deleted files: ${UNIQUE_ALL_DELETED}"
@@ -194,7 +194,7 @@ else
 
   if [[ -n $ALL_OTHER_DELETED ]]; then
     if [[ -n "$UNIQUE_ALL_DELETED" ]]; then
-      OTHER_DELETED=$(echo "${ALL_OTHER_DELETED}|${UNIQUE_ALL_DELETED}" | awk '{gsub(/\|/,"\n"); print $0;}' | sort | uniq -u | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
+      OTHER_DELETED=$(echo "${ALL_OTHER_DELETED}|${UNIQUE_ALL_DELETED}" | awk '{gsub(/\|/,"\n"); print $0;}' | uniq -u | awk -v d="|" '{s=(NR==1?s:s d)$0}END{print s}')
     else
       OTHER_DELETED=$ALL_OTHER_DELETED
     fi

--- a/sourcefiles.sh
+++ b/sourcefiles.sh
@@ -15,13 +15,13 @@ if [[ -n $INPUT_FILES_FROM_SOURCE_FILE ]]; then
   done
 fi
 
-IFS=" " read -r -a CLEAN_FILES <<< "$(echo "${RAW_FILES[*]}" | tr "\r\n" "\n" | tr " " "\n" | sort -u | awk -v d=" " '{s=(NR==1?s:s d)$0}END{print s}')"
+IFS=" " read -r -a CLEAN_FILES <<< "$(echo "${RAW_FILES[*]}" | tr "\r\n" "\n" | tr " " "\n" | awk '!a[$0]++' | awk -v d=" " '{s=(NR==1?s:s d)$0}END{print s}')"
 
-IFS=" " read -r -a CLEAN_INPUT_FILES <<< "$(echo "${INPUT_FILES}" | tr "\r\n" "\n" | tr " " "\n" | sort -u | awk -v d=" " '{s=(NR==1?s:s d)$0}END{print s}')"
+IFS=" " read -r -a CLEAN_INPUT_FILES <<< "$(echo "${INPUT_FILES}" | tr "\r\n" "\n" | tr " " "\n" | awk '!a[$0]++' | awk -v d=" " '{s=(NR==1?s:s d)$0}END{print s}')"
 
 FILES=("${CLEAN_FILES[@]}" "${CLEAN_INPUT_FILES[@]}")
 
-IFS=" " read -r -a ALL_UNIQUE_FILES <<< "$(echo "${FILES[@]}" | tr "\r\n" "\n" | tr " " "\n" | sort -u | awk -v d=" " '{s=(NR==1?s:s d)$0}END{print s}')"
+IFS=" " read -r -a ALL_UNIQUE_FILES <<< "$(echo "${FILES[@]}" | tr "\r\n" "\n" | tr " " "\n" | awk '!a[$0]++' | awk -v d=" " '{s=(NR==1?s:s d)$0}END{print s}')"
 
 echo "Input files: ${ALL_UNIQUE_FILES[*]}"
 

--- a/sourcefiles.sh
+++ b/sourcefiles.sh
@@ -15,9 +15,9 @@ if [[ -n $INPUT_FILES_FROM_SOURCE_FILE ]]; then
   done
 fi
 
-IFS=" " read -r -a CLEAN_FILES <<< "$(echo "${RAW_FILES[*]}" | tr "\r\n" "\n" | tr " " "\n" | awk '!a[$0]++' | awk -v d=" " '{s=(NR==1?s:s d)$0}END{print s}')"
+IFS=" " read -r -a CLEAN_FILES <<< "$(echo "${RAW_FILES[*]}" | tr "\r\n" "\n" | tr " " "\n" | awk -v d=" " '{s=(NR==1?s:s d)$0}END{print s}')"
 
-IFS=" " read -r -a CLEAN_INPUT_FILES <<< "$(echo "${INPUT_FILES}" | tr "\r\n" "\n" | tr " " "\n" | awk '!a[$0]++' | awk -v d=" " '{s=(NR==1?s:s d)$0}END{print s}')"
+IFS=" " read -r -a CLEAN_INPUT_FILES <<< "$(echo "${INPUT_FILES}" | tr "\r\n" "\n" | tr " " "\n" | awk -v d=" " '{s=(NR==1?s:s d)$0}END{print s}')"
 
 FILES=("${CLEAN_FILES[@]}" "${CLEAN_INPUT_FILES[@]}")
 

--- a/test/changed-files-list.txt
+++ b/test/changed-files-list.txt
@@ -2,4 +2,5 @@
 action.yml
 action.yml
 action.yml
+test/changed-files-list.txt
 !*.txt

--- a/test/changed-files-list.txt
+++ b/test/changed-files-list.txt
@@ -3,4 +3,4 @@ action.yml
 action.yml
 action.yml
 test/changed-files-list.txt
-!*.txt
+!**/*.txt


### PR DESCRIPTION
Excluded patterns ( `! ...` ) cannot be applied as intended due to deduplication of the `files` parameter by sorting.
Therefore, I modify this action to deduplicate from this parameter without sorting.