### PR TITLE
improvement: Simplify checks

### DIFF
--- a/diff-sha.sh
+++ b/diff-sha.sh
@@ -17,7 +17,7 @@ if [[ -n $INPUT_PATH ]]; then
   cd "$REPO_DIR"
 fi
 
-git --version 1>/dev/null 2>&1 && exit_status=$? || exit_status=$?
+git --version 1>/dev/null 2>&1 ; exit_status=$?
 
 if [[ $exit_status -ne 0 ]]; then
   echo "::error::git not installed"
@@ -27,12 +27,12 @@ fi
 echo "::debug::Getting HEAD SHA..."
 
 if [[ -z $INPUT_SHA ]]; then
-  CURRENT_SHA=$(git rev-list -n 1 "HEAD" 2>&1) && exit_status=$? || exit_status=$?
+  CURRENT_SHA=$(git rev-list -n 1 "HEAD" 2>&1) ; exit_status=$?
 else
-  CURRENT_SHA=$INPUT_SHA && exit_status=$? || exit_status=$?
+  CURRENT_SHA=$INPUT_SHA ; exit_status=$?
 fi
 
-git rev-parse --quiet --verify "$CURRENT_SHA^{commit}" 1>/dev/null 2>&1 && exit_status=$? || exit_status=$?
+git rev-parse --quiet --verify "$CURRENT_SHA^{commit}" 1>/dev/null 2>&1 ; exit_status=$?
 
 if [[ $exit_status -ne 0 ]]; then
   echo "::error::Unable to locate the current sha: $CURRENT_SHA"
@@ -51,22 +51,22 @@ if [[ -z $GITHUB_BASE_REF ]]; then
 
   if [[ -z $INPUT_BASE_SHA ]]; then
     if [[ $(git rev-list --count "HEAD") -gt 1 ]]; then
-      PREVIOUS_SHA=$(git rev-parse "@~" 2>&1) && exit_status=$? || exit_status=$?
+      PREVIOUS_SHA=$(git rev-parse "@~" 2>&1) ; exit_status=$?
       echo "::debug::Previous SHA: $PREVIOUS_SHA"
     else
-      PREVIOUS_SHA=$CURRENT_SHA && exit_status=$? || exit_status=$?
+      PREVIOUS_SHA=$CURRENT_SHA ; exit_status=$?
       INITIAL_COMMIT="true"
       echo "::debug::Initial commit detected"
       echo "::debug::Previous SHA: $PREVIOUS_SHA"
     fi
   else
-    PREVIOUS_SHA=$INPUT_BASE_SHA && exit_status=$? || exit_status=$?
-    TARGET_BRANCH=$(git name-rev --name-only "$PREVIOUS_SHA" 2>&1) && exit_status=$? || exit_status=$?
+    PREVIOUS_SHA=$INPUT_BASE_SHA ; exit_status=$?
+    TARGET_BRANCH=$(git name-rev --name-only "$PREVIOUS_SHA" 2>&1) ; exit_status=$?
     echo "::debug::Previous SHA: $PREVIOUS_SHA"
     echo "::debug::Target branch: $TARGET_BRANCH"
   fi
 
-  git rev-parse --quiet --verify "$PREVIOUS_SHA^{commit}" 1>/dev/null 2>&1 && exit_status=$? || exit_status=$?
+  git rev-parse --quiet --verify "$PREVIOUS_SHA^{commit}" 1>/dev/null 2>&1 ; exit_status=$?
 
   if [[ $exit_status -ne 0 ]]; then
     echo "::error::Unable to locate the previous sha: $PREVIOUS_SHA"
@@ -82,24 +82,24 @@ else
   if [[ -z $INPUT_BASE_SHA ]]; then
     if [[ "$INPUT_USE_FORK_POINT" == "true" ]]; then
       echo "::debug::Getting fork point..."
-      git fetch --no-tags -u --progress origin "${TARGET_BRANCH}":"${TARGET_BRANCH}" && exit_status=$? || exit_status=$?
-      PREVIOUS_SHA=$(git merge-base --fork-point "${TARGET_BRANCH}" "$(git name-rev --name-only "$CURRENT_SHA")") && exit_status=$? || exit_status=$?
+      git fetch --no-tags -u --progress origin "${TARGET_BRANCH}":"${TARGET_BRANCH}" ; exit_status=$?
+      PREVIOUS_SHA=$(git merge-base --fork-point "${TARGET_BRANCH}" "$(git name-rev --name-only "$CURRENT_SHA")") ; exit_status=$?
       echo "::debug::Previous SHA: $PREVIOUS_SHA"
     else
-      git fetch --no-tags -u --progress origin --depth=1 "${TARGET_BRANCH}":"${TARGET_BRANCH}" && exit_status=$? || exit_status=$?
-      PREVIOUS_SHA=$(git rev-list -n 1 "${TARGET_BRANCH}" 2>&1) && exit_status=$? || exit_status=$?
+      git fetch --no-tags -u --progress origin --depth=1 "${TARGET_BRANCH}":"${TARGET_BRANCH}" ; exit_status=$?
+      PREVIOUS_SHA=$(git rev-list -n 1 "${TARGET_BRANCH}" 2>&1) ; exit_status=$?
       echo "::debug::Previous SHA: $PREVIOUS_SHA"
     fi
   else
-    git fetch --no-tags -u --progress origin --depth=1 "$INPUT_BASE_SHA" && exit_status=$? || exit_status=$?
+    git fetch --no-tags -u --progress origin --depth=1 "$INPUT_BASE_SHA" ; exit_status=$?
     PREVIOUS_SHA=$INPUT_BASE_SHA
-    TARGET_BRANCH=$(git name-rev --name-only "$PREVIOUS_SHA" 2>&1) && exit_status=$? || exit_status=$?
+    TARGET_BRANCH=$(git name-rev --name-only "$PREVIOUS_SHA" 2>&1) ; exit_status=$?
     echo "::debug::Previous SHA: $PREVIOUS_SHA"
     echo "::debug::Target branch: $TARGET_BRANCH"
   fi
 
   echo "::debug::Verifying commit SHA..."
-  git rev-parse --quiet --verify "$PREVIOUS_SHA^{commit}" 1>/dev/null 2>&1 && exit_status=$? || exit_status=$?
+  git rev-parse --quiet --verify "$PREVIOUS_SHA^{commit}" 1>/dev/null 2>&1 ; exit_status=$?
 
   if [[ $exit_status -ne 0 ]]; then
     echo "::error::Unable to locate the previous sha: $PREVIOUS_SHA"


### PR DESCRIPTION
Just pointing that the `&&` and `||` on `bash` are not equivalent to the `if ... then ... else`, as you can get more details [here](https://stackoverflow.com/a/21913843/8538179).

You can simplify the way to save the `exit_status` from this

```bash
COMMAND && exit_status=$? || exit_status=$?
```

to this

```bash
COMMAND ; exit_status=$?
```

Thanks!