### PR TITLE
chore: change `sha` to non-required

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ inputs:
     default: ""
   sha:
     description: "Specify a different commit SHA used for comparing changes"
-    required: true
+    required: false
     default: ${{ github.sha }}
   base_sha:
     description: "Specify a different base commit SHA used for comparing changes"


### PR DESCRIPTION
I found that my IDE raises a warning about this.
![image](https://user-images.githubusercontent.com/31987104/200153791-bb4a2d3f-2f93-4784-8020-2c22143af91d.png)

Since the default value is set, I think the `required` field can be `false`.

Related: This option was added in https://github.com/tj-actions/changed-files/pull/126.