### PR TITLE
correct bash loop in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,7 +728,7 @@ The format of the version string is as follows:
       env:
         ADDED_FILES: ${{ steps.changed-files.outputs.added_files }}
       run: |
-        for file in "$ADDED_FILES"; do
+        for file in ${ADDED_FILES}; do
           echo "$file was added"
         done
 ...
@@ -766,7 +766,7 @@ See [inputs](#inputs) for more information.
       env:
         ADDED_FILES: ${{ steps.changed-files.outputs.added_files }}
       run: |
-        for file in "$ADDED_FILES"; do
+        for file in ${ADDED_FILES}; do
           echo "$file was added"
         done
 ...
@@ -891,7 +891,7 @@ See [inputs](#inputs) for more information.
       env:
         DELETED_FILES: ${{ steps.changed-files-specific.outputs.deleted_files }}
       run: |
-        for file in "$DELETED_FILES"; do
+        for file in ${DELETED_FILES}; do
           echo "$file was deleted"
         done
 
@@ -900,7 +900,7 @@ See [inputs](#inputs) for more information.
       env:
         DELETED_FILES: ${{ steps.changed-files-specific.outputs.deleted_files }}
       run: |
-        for file in "$DELETED_FILES"; do
+        for file in ${DELETED_FILES}; do
           echo "$file was deleted"
         done
 ...
@@ -1049,7 +1049,7 @@ See [inputs](#inputs) for more information.
         ADDED_FILES: |-
           ${{ steps.changed-files-for-dir1.outputs.added_files }}
       run: |
-        for file in "$ADDED_FILES"; do
+        for file in ${ADDED_FILES}; do
           echo "$file was added"
         done
 ...

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-          for file in "$ALL_CHANGED_FILES"; do
+          for file in ${ALL_CHANGED_FILES}; do
             echo "$file was changed"
           done
 
@@ -149,7 +149,7 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-markdown-files.outputs.all_changed_files }}
         run: |
-          for file in "$ALL_CHANGED_FILES"; do
+          for file in ${ALL_CHANGED_FILES}; do
             echo "$file was changed"
           done
 
@@ -237,7 +237,7 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-          for file in "$ALL_CHANGED_FILES"; do
+          for file in ${ALL_CHANGED_FILES}; do
             echo "$file was changed"
           done
 ```
@@ -281,7 +281,7 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-          for file in "$ALL_CHANGED_FILES"; do
+          for file in ${ALL_CHANGED_FILES}; do
             echo "$file was changed"
           done
       ...


### PR DESCRIPTION
The examples have the ALL_CHANGED_FILES variable in double quotes which prevents bash from expanding it, resulting in:
```
fileA.txt fileB.txt was changed
```
instead of the intended:
```
fileA.txt was changed
fileB.txt was changed
```