### PR TITLE
fix: broken link to matrix example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ Support this project with a :star:
 
     # Output list of changed files in a JSON formatted 
     # string which can be used for matrix jobs. Example: 
-    # https://github.com/tj-actions/changed-files/blob/main/.github/workflows/matrix-test.yml 
+    # https://github.com/tj-actions/changed-files/blob/main/.github/workflows/matrix-example.yml 
     # Type: boolean
     # Default: "false"
     json: ''

--- a/action.yml
+++ b/action.yml
@@ -127,7 +127,7 @@ inputs:
     required: false
     default: "false"
   json:
-    description: "Output list of changed files in a JSON formatted string which can be used for matrix jobs. Example: https://github.com/tj-actions/changed-files/blob/main/.github/workflows/matrix-test.yml"
+    description: "Output list of changed files in a JSON formatted string which can be used for matrix jobs. Example: https://github.com/tj-actions/changed-files/blob/main/.github/workflows/matrix-example.yml"
     required: false
     default: "false"
   escape_json:


### PR DESCRIPTION
## Why

Because the link was broken, I got 404. 
It should be linked to this file → https://github.com/tj-actions/changed-files/blob/main/.github/workflows/matrix-example.yml