### PR TITLE
fix(payload_api, git_diff): Accessing correct property in payload and Replacing --quiet with --no-patch in git diff

### DIFF
--- a/src/commitSha.ts
+++ b/src/commitSha.ts
@@ -429,7 +429,7 @@ export const getSHAForPullRequestEvent = async (
 
   if (
     !github.context.payload.pull_request?.base?.ref ||
-    github.context.payload.head?.repo?.fork === 'true'
+    github.context.payload.pull_request?.head?.repo?.fork === true
   ) {
     diff = '..'
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -908,7 +908,7 @@ export const canDiffCommits = async ({
   } else {
     const {exitCode, stderr} = await exec.getExecOutput(
       'git',
-      ['diff', '--quiet', sha1, sha2],
+      ['diff', '--no-patch', sha1, sha2],
       {
         cwd,
         ignoreReturnCode: true,


### PR DESCRIPTION
#### 1. Replacing `github.context.payload.head` with `github.context.payload.pull_request?.head` 
`github.context.payload.head` is always `undefined` and github doc also there is no evidence this exist,
So while trying `github.context.payload.pull_request?.head` this returns the expected `head` object and can propogates to `fork`
and also `fork` is `boolean` not a string.
<i>this is found during why the action reached this [`if` block](https://github.com/tj-actions/changed-files/blob/main/src/commitSha.ts#L434) due to avoid `git merge-base` and seems it could be a accidental mistake</i>

#### 2. Replacing `--quiet` with `--no-patch`
As of now, seems every `git` commands are returning exitcode and if the exit code is none other than 0
we are assuming that operation is not completed successfully which is correct but except
`git diff --quiet` would return exit code `0` if there are no differences, but returns `1` if there is any differences.
as they mentioned [here](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---quiet) , `--quiet` would add 
`--exit-code`.

> Make the program exit with codes similar to diff(1). That is, it exits with 1 if there were differences and 0 means no differences.

As they mentioned [here](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---exit-code).
So seems it not expected, but we have similar flag to run git diff with no outputs, which is [`--no-patch`](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---no-patch)


<i>These all are found while try to avoid fetching more histories to save time from the eslint-changed-files action and this is a follow up of https://github.com/tj-actions/eslint-changed-files/pull/1633</i>